### PR TITLE
added directive for intrinsic isinf()

### DIFF
--- a/logdouble.hpp
+++ b/logdouble.hpp
@@ -8,6 +8,7 @@
 
 using std::min;
 using std::max;
+using std::isinf;
 
 class logdouble {
  public:


### PR DESCRIPTION
This repository fails to build under Fedora 25 with GCC 6.3.1 due to undeclared function ```isinf()```.

I have simply added this as with ```min``` and ```max```.
